### PR TITLE
doc: add a warning about permissible tree depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ misc:
 # world_id_contract_commit_hash: '2e2d25f1c45b07657e8830fb85a5221941aac68e'
 ```
 
+Notes on values:
+ - `tree_depth` is limited by [the Semaphore](https://github.com/worldcoin/semaphore-v3). Permissible [range 16-32](https://github.com/worldcoin/world-id-contracts/blob/master/src/utils/SemaphoreTreeDepthValidator.sol#L13-L14)
+
 ### Groups
 
 The `groups` section is a map where each key is a `GroupId` and the value is a `GroupConfig`. Each `GroupConfig` has two properties: `tree_depth` and `batch_sizes`.

--- a/src/deployment/steps/identity_manager.rs
+++ b/src/deployment/steps/identity_manager.rs
@@ -119,7 +119,7 @@ async fn deploy_world_id_identity_manager_for_group(
     let call_data = encode_function_data(
         initialize_func,
         (
-            group_config.tree_depth.0 as u64,
+            group_config.tree_depth.0 as u8,
             initial_root_u256,
             insert_lookup_table_address,
             update_lookup_table_address,


### PR DESCRIPTION
If the depth in the config is outside of permissible range, deploy will fail with cryptic error:
```
   0: forge create failed: Error:
      server returned an error response: error code 3: execution reverted:
```